### PR TITLE
Add dynamodb sidecar container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ jobs:
 
     docker:
       - image: circleci/ruby:2.4
+        environment:
+          - DYNAMODB_CREATE_TEST_TABLE: 1
+          - DYNAMODB_ENDPOINT: "http://localhost:8000"
+      - image: amazon/dynamodb-local
 
     steps:
       - checkout


### PR DESCRIPTION
In order to run our tests without an actual connection to aws